### PR TITLE
reverting  changes for debug option

### DIFF
--- a/bin/pakiti-client
+++ b/bin/pakiti-client
@@ -386,7 +386,6 @@ sub send_report ($) {
     $output = qx(@command "$url" 2>&1);
     if ($output =~ /$Option{expect}/ and $? == 0) {
         print(STDERR "report successfully sent\n") if -t STDERR;
-        print $output if $output;
         return;
     }
     warn($output) if $output;

--- a/bin/pakiti-client
+++ b/bin/pakiti-client
@@ -361,8 +361,7 @@ sub send_report ($) {
     write_file($data, $report);
     if ($Option{curl}) {
         @command = ($Option{curl});
-        push(@command, qw(-q --silent -X POST));
-        push(@command, qw(--include --show-error)) if $Option{debug};
+        push(@command, qw(-q --include --silent --show-error -X POST));
         push(@command, "--data-binary", "\@" . $data);
     } elsif ($Option{wget}) {
         @command = ($Option{wget});
@@ -385,7 +384,7 @@ sub send_report ($) {
     $url = $url . '?' . join('&', @pairs) if @pairs;
     ## no critic 'InputOutput::ProhibitBacktickOperators'
     $output = qx(@command "$url" 2>&1);
-    if ($output =~ /$Option{expect}$/ and $? == 0) {
+    if ($output =~ /$Option{expect}/ and $? == 0) {
         print(STDERR "report successfully sent\n") if -t STDERR;
         print $output if $output;
         return;


### PR DESCRIPTION
the  changes did in this commit 
https://github.com/CESNET/pakiti-client/commit/2a3a092ebd2f2faa3bc4653188fc215a80410999

makes the client reporting an error now when using the pkgdb at cern, while the server correctly stores the report.

It seems that the server does not report  back the "OK" string if we don't pass the --show-error option. Infact the client does not complain if i run the pakiti-client  with -d option.

Could be that the problem is server side but if those changes are not essential i would prefer to revert them.