### PR TITLE
Use package manager with zero return value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+debian/debhelper-build-stamp
+debian/files
+debian/pakiti-client.debhelper.log
+debian/pakiti-client.substvars
+debian/pakiti-client/
+pakiti-client.1
+

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pakiti (3.0.4) stable; urgency=medium
+
+  * Fix uninitialized value on Debian/Sid
+
+ -- Michal Svamberg <svamberg@civ.zcu.cz>  Mon, 25 Feb 2019 10:43:58 +0100
+
 pakiti (3.0.3) stable; urgency=medium
 
   * Improve selection of package manager

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+pakiti (3.0.3) stable; urgency=medium
+
+  * Improve selection of package manager
+  * Change detecting OS from issue.net to os-release file
+
+ -- Michal Svamberg <svamberg@civ.zcu.cz>  Mon, 25 Feb 2019 10:01:34 +0100
+
 pakiti (3.0.2) stable; urgency=medium
 
   * Support for installations with multiple package managers

--- a/pakiti-client
+++ b/pakiti-client
@@ -263,16 +263,16 @@ sub find_packages ($) {
         $format = "%{NAME}\t%{EPOCH}:%{VERSION}-%{RELEASE}\t%{ARCH}";
         ## no critic 'InputOutput::ProhibitBacktickOperators'
         @output = qx($cmd -qa --queryformat "$format\n");
-        return if $?;
-
-        if (@output) {
-            foreach my $line (@output) {
-                $line =~ s{\t\(none\):}{\t0:}g;
-                push(@list, $line) unless $line =~ /^gpg-pubkey\t/;
-            }
-            $data->{packages} = join("", sort(@list));
-            return;
-        }
+        if ($? == 0) {
+			if (@output) {
+				foreach my $line (@output) {
+				$line =~ s{\t\(none\):}{\t0:}g;
+				push(@list, $line) unless $line =~ /^gpg-pubkey\t/;
+				}
+				$data->{packages} = join("", sort(@list));
+				return;
+			}
+		}
     }
     # Debian packages
     $cmd = $Option{"dpkg-query"};
@@ -282,18 +282,18 @@ sub find_packages ($) {
                           qw(Status Package Version Architecture));
         ## no critic 'InputOutput::ProhibitBacktickOperators'
         @output = qx($cmd -W --showformat="$format\n");
-        return if $?;
-
-        if (@output) {
-            foreach my $line (@output) {
-                if ($line =~ /^install ok installed/) {
-                    $line =~ s{^.+?=}{}g;
-                    push(@list, $line);
-                }
-            }
-            $data->{packages} = join("", sort(@list));
-            return;
-        }
+        if ($? == 0) {
+			if (@output) {
+				foreach my $line (@output) {
+					if ($line =~ /^install ok installed/) {
+						$line =~ s{^.+?=}{}g;
+						push(@list, $line);
+					}
+				}
+				$data->{packages} = join("", sort(@list));
+				return;
+			}
+		}
     }
     # OpenBSD (pkg) or FreeBSD (pkgng) packages
     $cmd = $Option{"pkg"};
@@ -301,17 +301,17 @@ sub find_packages ($) {
         $data->{packager} = "pkg";
         ## no critic 'InputOutput::ProhibitBacktickOperators'
         @output = qx($cmd info);
-        return if $?;
-
-        if (@output) {
-            foreach my $line (@output) {
-                $line =~ s{\s+.*$}{};
-                $line =~ s{-([0-9])}{\t$1};
-                push(@list, "$line\t$data->{arch}\n");
-            }
-            $data->{packages} = join("", sort(@list));
-            return;
-        }
+        if ($? == 0) {
+			if (@output) {
+				foreach my $line (@output) {
+					$line =~ s{\s+.*$}{};
+					$line =~ s{-([0-9])}{\t$1};
+					push(@list, "$line\t$data->{arch}\n");
+				}
+				$data->{packages} = join("", sort(@list));
+				return;
+			}
+		}
     }
     # unknown or not working!
     die("$Script: package manager unknown or not working properly\n");

--- a/pakiti-client
+++ b/pakiti-client
@@ -170,7 +170,7 @@ sub find_host ($) {
 
 sub find_system ($) {
     my($data) = @_;
-    my($path, $output, @list);
+    my($path, $output, @list, %os_release);
 
     # running kernel
     if ($Option{uname}) {
@@ -187,8 +187,16 @@ sub find_system ($) {
     if (-f "/etc/os-release") {
         $_ = read_file("/etc/os-release");
         $_ =~ s/"//g;
-        my %os_release = map{split /=/, $_}(split /\n/, $_);
-        $data->{system} = "$os_release{NAME} $os_release{VERSION_ID}";
+        %os_release = map{split /=/, $_}(split /\n/, $_);
+	if ($os_release{PRETTY_NAME} ne "") {
+		$data->{system} = "$os_release{PRETTY_NAME}";
+		return;
+	}
+	if ($os_release{VERSION_ID}) {
+	        $data->{system} = "$os_release{NAME} $os_release{VERSION_ID}";
+	} else {
+	        $data->{system} = "$os_release{NAME}";
+	}
         return;
     }
     $path = "/etc/SuSE-release";


### PR DESCRIPTION
On Debian you cat installed rpm package without database
(needs for alien package). In this case return 'rpm -qa' error
status and pakiti-client exited. Now pakiti-client tried dpkg.