### PR TITLE
Add --bind-address option to restrict source IP.

### DIFF
--- a/pakiti-client
+++ b/pakiti-client
@@ -386,6 +386,9 @@ sub send_report ($) {
     $url = $url . '?' . join('&', @pairs) if @pairs;
 
     $ua = LWP::UserAgent->new();
+    if ($Option{'bind-address'}) {
+	$ua->local_address($Option{'bind-address'});
+    }
     push @{$ua->requests_redirectable}, 'POST';
 
     if ($Option{"disable-tls-checks"}) {
@@ -446,6 +449,7 @@ sub init () {
 
     $| = 1;
     %spec = (
+	"bind-address" => "=s",
         "config"   => "|conf=s",
         "encrypt"  => "=s",
         "disable-tls-checks" => "",
@@ -619,6 +623,11 @@ with (using bash):
 =head1 OPTIONS
 
 =over
+
+=item B<--bind-address> I<ADDRESS>
+
+bind to this local address for the outgoing connection; useful for fulfilling
+firewall rules and for uniquely identifying the host
 
 =item B<--config>, B<--conf> I<PATH>
 


### PR DESCRIPTION
This adds an option to specify the address from which to contact the server in case the host have multiple.  This helps controlling the implied identifier and may in some cases be needed for routing purposes.

We have been using this for a while now, but I seem to have forgotten to send a PR.
